### PR TITLE
MCORE-73 add new dsl methods

### DIFF
--- a/Sources/CoreUITestKit/AllureReportExtensions.swift
+++ b/Sources/CoreUITestKit/AllureReportExtensions.swift
@@ -1,3 +1,6 @@
+//
+// Copyright © 2023 LLC "Globus Media". All rights reserved.
+//
 
 import XCTest
 

--- a/Sources/CoreUITestKit/BaseTestCase.md
+++ b/Sources/CoreUITestKit/BaseTestCase.md
@@ -1,3 +1,6 @@
+//
+// Copyright © 2023 LLC "Globus Media". All rights reserved.
+//
 
 import Foundation
 import XCTest

--- a/Sources/CoreUITestKit/XCTestCase+.swift
+++ b/Sources/CoreUITestKit/XCTestCase+.swift
@@ -1,3 +1,6 @@
+//
+// Copyright © 2023 LLC "Globus Media". All rights reserved.
+//
 
 import Foundation
 import XCTest

--- a/Sources/CoreUITestKit/XCUICoordinate+.swift
+++ b/Sources/CoreUITestKit/XCUICoordinate+.swift
@@ -1,0 +1,12 @@
+
+import XCTest
+import Foundation
+
+extension XCUICoordinate {
+    public func dsl_press(forDuration: TimeInterval, thenDragTo: XCUICoordinate) {
+        let resourceName = self.description
+        return XCTContext.runActivity(named: "Пресс тап по элементу \(String(describing: resourceName))") { _ in
+            self.press(forDuration: forDuration, thenDragTo: thenDragTo)
+        }
+    }
+}

--- a/Sources/CoreUITestKit/XCUICoordinate+.swift
+++ b/Sources/CoreUITestKit/XCUICoordinate+.swift
@@ -1,3 +1,6 @@
+//
+// Copyright © 2023 LLC "Globus Media". All rights reserved.
+//
 
 import XCTest
 import Foundation

--- a/Sources/CoreUITestKit/XCUICoordinate+.swift
+++ b/Sources/CoreUITestKit/XCUICoordinate+.swift
@@ -3,10 +3,10 @@ import XCTest
 import Foundation
 
 extension XCUICoordinate {
-    public func dsl_press(forDuration: TimeInterval, thenDragTo: XCUICoordinate) {
+    public func dsl_press(forDuration duration: TimeInterval, thenDragTo dragTo: XCUICoordinate) {
         let resourceName = self.description
         return XCTContext.runActivity(named: "Пресс тап по элементу \(String(describing: resourceName))") { _ in
-            self.press(forDuration: forDuration, thenDragTo: thenDragTo)
+            self.press(forDuration: duration, thenDragTo: dragTo)
         }
     }
 }

--- a/Sources/CoreUITestKit/XCUIElement+.swift
+++ b/Sources/CoreUITestKit/XCUIElement+.swift
@@ -123,14 +123,15 @@ extension XCUIElement {
         }
     }
 
-    public func dsl_typeText(_ text: String, needWait: Bool? = false, file: StaticString = #file, line: UInt = #line) {
+    public func dsl_typeText(_ text: String, needWait: Bool = false, file: StaticString = #file, line: UInt = #line) {
         let resourceName = self.description
         XCTContext.runActivity(named: "Ввод текста \(text) в \(String(describing: resourceName))") { _ in
-            if needWait == true {
+            if needWait {
                 guard dsl_waitForHittable(timeout: 5) else {
-                    XCTFail("Элемент \(String(describing: resourceName)) не готов для нажатия",
-                            file: file,
-                            line: line
+                    XCTFail(
+                        "Элемент \(String(describing: resourceName)) не готов для нажатия",
+                        file: file,
+                        line: line
                     )
                     return
                 }
@@ -145,14 +146,15 @@ extension XCUIElement {
         }
     }
     
-    public func dsl_tap(needWait: Bool? = false, file: StaticString = #file, line: UInt = #line) {
+    public func dsl_tap(needWait: Bool = false, file: StaticString = #file, line: UInt = #line) {
         let resourceName = self.description
         XCTContext.runActivity(named: "Тап по элементу \(String(describing: resourceName))") { _ in
-            if needWait == true {
+            if needWait {
                 guard dsl_waitForHittable(timeout: 5) else {
-                    XCTFail("Элемент \(String(describing: resourceName)) не готов для нажатия",
-                             file: file,
-                             line: line
+                    XCTFail(
+                        "Элемент \(String(describing: resourceName)) не готов для нажатия",
+                        file: file,
+                        line: line
                     )
                     return
                 }
@@ -167,14 +169,15 @@ extension XCUIElement {
         }
     }
     
-    public func dsl_doubleTap(needWait: Bool? = false, file: StaticString = #file, line: UInt = #line) {
+    public func dsl_doubleTap(needWait: Bool = false, file: StaticString = #file, line: UInt = #line) {
         let resourceName = self.description
         XCTContext.runActivity(named: "Двойной Тап по элементу \(String(describing: resourceName))") { _ in
-            if needWait == true {
+            if needWait {
                 guard dsl_waitForHittable(timeout: 5) else {
-                    XCTFail("Элемент \(String(describing: resourceName)) не готов для нажатия",
-                             file: file,
-                             line: line
+                    XCTFail(
+                        "Элемент \(String(describing: resourceName)) не готов для нажатия",
+                        file: file,
+                        line: line
                     )
                     return
                 }
@@ -201,14 +204,7 @@ extension XCUIElement {
     public func dsl_tap(withNumberOfTaps: Int) {
         let resourceName = self.description
         
-        let numberOfTapsText: String
-        if withNumberOfTaps >= 2 && withNumberOfTaps <= 4 {
-            numberOfTapsText = "\(withNumberOfTaps) раза"
-        } else {
-            numberOfTapsText = "\(withNumberOfTaps) раз"
-        }
-        
-        XCTContext.runActivity(named: "Тап по элементу \(String(describing: resourceName)) \(numberOfTapsText)") { _ in
+        XCTContext.runActivity(named: "Тап по элементу \(String(describing: resourceName)) \(withNumberOfTaps) раз(а)") { _ in
             tap(withNumberOfTaps: withNumberOfTaps, numberOfTouches: 1)
         }
     }
@@ -358,9 +354,10 @@ extension XCUIElement {
         XCTContext.runActivity(named: "Удаление текста '\(String(describing: resourceName))' через клавиатуру") {  _ in
             tap()
             guard let stringValue = value as? String else {
-                XCTFail("Tried to clear and enter text into a non string value!",
-                file: file,
-                line: line
+                XCTFail(
+                    "Tried to clear and enter text into a non string value!",
+                    file: file,
+                    line: line
                 )
                 return
             }
@@ -384,7 +381,7 @@ extension XCUIElement {
         XCTContext.runActivity(named: "Скролл до элемента \(element)") { _ in
             let maxScrolls = 10
             for _ in 0 ..< maxScrolls {
-                if element.dsl_waitForExistence(timeout: 3) && element.dsl_waitForHittable(timeout: 3){
+                if element.dsl_waitForExistence(timeout: 3) && element.dsl_waitForHittable(timeout: 3) {
                     return
                 }
                 
@@ -392,7 +389,11 @@ extension XCUIElement {
                 let endCoord = coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: scrollDirection == .up ? 1 : 0))
                 startCoord.dsl_press(forDuration: 0, thenDragTo: endCoord)
             }
-            XCTFail("Не удалось доскроллить до элемента \(element) за \(maxScrolls) попыток", file: file, line: line)
+            XCTFail(
+                "Не удалось доскроллить до элемента \(element) за \(maxScrolls) раз(а)",
+                file: file,
+                line: line
+            )
         }
     }
     

--- a/Sources/CoreUITestKit/XCUIElement+.swift
+++ b/Sources/CoreUITestKit/XCUIElement+.swift
@@ -64,7 +64,7 @@ extension XCUIElement {
     }
     
     /// Выбор  элемента по тексту в пикере
-    public func dsl_adjust(toPickerWheelValue: String, file: StaticString = #file, line: UInt = #line) {
+    public func dsl_adjust(toPickerWheelValue: String) {
         let resourceName = self.description
         XCTContext.runActivity(named: "Тап по тексту '\(toPickerWheelValue)' в  елементе \(String(describing: resourceName))") { _ in
             adjust(toPickerWheelValue: toPickerWheelValue)
@@ -114,7 +114,7 @@ extension XCUIElement {
     }
     
     @discardableResult
-    public func dsl_waitForHittable(timeout: Double, file: StaticString = #file, line: UInt = #line) -> Bool {
+    public func dsl_waitForHittable(timeout: Double) -> Bool {
         let resourceName = self.description
         return XCTContext.runActivity(named: "Подождать, пока элемент \(String(describing: resourceName)) станет кликабельным") { _ in
             let expectation = XCTNSPredicateExpectation(
@@ -196,7 +196,7 @@ extension XCUIElement {
     }
     
     ///  Принудительный Тап  по координатам
-    public func dsl_forceTap(file: StaticString = #file, line: UInt = #line) {
+    public func dsl_forceTap() {
         let resourceName = self.description
         XCTContext.runActivity(named: "Тап по скрытому элементу \(String(describing: resourceName))") { _ in
             coordinate(withNormalizedOffset: CGVector(dx: 0.0, dy: 0.0)).tap()

--- a/Sources/CoreUITestKit/XCUIElement+.swift
+++ b/Sources/CoreUITestKit/XCUIElement+.swift
@@ -380,7 +380,7 @@ extension XCUIElement {
     /// - parameters:
     ///     - element: Искомый элемент.
     ///     - withDirection: Направление скролла
-    func dsl_scrollTo(element: XCUIElement, withDirection scrollDirection: GestureDirection, file: StaticString = #file, line: UInt = #line) {
+    public func dsl_scrollTo(element: XCUIElement, withDirection scrollDirection: GestureDirection, file: StaticString = #file, line: UInt = #line) {
         XCTContext.runActivity(named: "Скролл до элемента \(element)") { _ in
             let maxScrolls = 10
             for _ in 0 ..< maxScrolls {

--- a/Sources/CoreUITestKit/XCUIElement+.swift
+++ b/Sources/CoreUITestKit/XCUIElement+.swift
@@ -358,6 +358,27 @@ extension XCUIElement {
             }
         }
     }
+
+    /// Автоматический скролл до элемента
+    /// Дистанция одной прокрутки - половина высоты элемента, к которому применяется метод
+    /// - parameters:
+    ///     - element: Искомый элемент.
+    ///     - withDirection: Направление скролла
+    func dsl_scrollTo(element: XCUIElement, withDirection scrollDirection: GestureDirection, file: StaticString = #file, line: UInt = #line) {
+        XCTContext.runActivity(named: "Скролл до элемента \(element)") { _ in
+            let maxScrolls = 10
+            for _ in 0 ..< maxScrolls {
+                if element.dsl_waitForExistence(timeout: 3) && element.dsl_waitForHittable(timeout: 3){
+                    return
+                }
+                
+                let startCoord = coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5))
+                let endCoord = coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: scrollDirection == .up ? 1 : 0))
+                startCoord.dsl_press(forDuration: 0, thenDragTo: endCoord)
+            }
+            XCTFail("Не удалось доскроллить до элемента \(element) за \(maxScrolls) попыток", file: file, line: line)
+        }
+    }
     
     public enum KeyboardLayout: String {
         case RU
@@ -365,11 +386,17 @@ extension XCUIElement {
         case Number
     }
     
+    /// Направление свайпа
     public enum Direction: Int {
         case up
         case down
         case left
         case right
+    }
+    
+    /// Направление скролла
+    public enum GestureDirection {
+        case up, down
     }
     
     public enum Action: String {

--- a/Sources/CoreUITestKit/XCUIElement+.swift
+++ b/Sources/CoreUITestKit/XCUIElement+.swift
@@ -197,6 +197,22 @@ extension XCUIElement {
         }
     }
     
+    ///  Мульти Тап
+    public func dsl_tap(withNumberOfTaps: Int) {
+        let resourceName = self.description
+        
+        let numberOfTapsText: String
+        if withNumberOfTaps >= 2 && withNumberOfTaps <= 4 {
+            numberOfTapsText = "\(withNumberOfTaps) раза"
+        } else {
+            numberOfTapsText = "\(withNumberOfTaps) раз"
+        }
+        
+        XCTContext.runActivity(named: "Тап по элементу \(String(describing: resourceName)) \(numberOfTapsText)") { _ in
+            tap(withNumberOfTaps: withNumberOfTaps, numberOfTouches: 1)
+        }
+    }
+    
     /// Стандартный свайп
     public func dsl_swipe(_ direction: Direction) {
         switch direction {

--- a/Sources/CoreUITestKit/XCUIElement+.swift
+++ b/Sources/CoreUITestKit/XCUIElement+.swift
@@ -1,3 +1,6 @@
+//
+// Copyright © 2023 LLC "Globus Media". All rights reserved.
+//
 
 import XCTest
 import Foundation
@@ -377,9 +380,8 @@ extension XCUIElement {
     /// - parameters:
     ///     - element: Искомый элемент.
     ///     - withDirection: Направление скролла
-    public func dsl_scrollTo(element: XCUIElement, withDirection scrollDirection: GestureDirection, file: StaticString = #file, line: UInt = #line) {
+    public func dsl_scrollTo(element: XCUIElement, withDirection scrollDirection: GestureDirection, maxScrolls: Int = 10, file: StaticString = #file, line: UInt = #line) {
         XCTContext.runActivity(named: "Скролл до элемента \(element)") { _ in
-            let maxScrolls = 10
             for _ in 0 ..< maxScrolls {
                 if element.dsl_waitForExistence(timeout: 3) && element.dsl_waitForHittable(timeout: 3) {
                     return

--- a/Sources/CoreUITestKit/XCUIElementQuery+.swift
+++ b/Sources/CoreUITestKit/XCUIElementQuery+.swift
@@ -1,0 +1,12 @@
+
+import Foundation
+import XCTest
+
+extension XCUIElementQuery {
+    public var dsl_count: Int {
+        let resourceName = self.element
+        return XCTContext.runActivity(named: "Получить колличество элемента \(String(describing: resourceName))") { _ in
+            return self.count
+        }
+    }
+}

--- a/Sources/CoreUITestKit/XCUIElementQuery+.swift
+++ b/Sources/CoreUITestKit/XCUIElementQuery+.swift
@@ -1,3 +1,6 @@
+//
+// Copyright © 2023 LLC "Globus Media". All rights reserved.
+//
 
 import Foundation
 import XCTest


### PR DESCRIPTION
в рамках задачи https://hq.tutu.ru/browse/MCORE-73  выполнено:

1) Добавлен метод dsl_scrollTo() - метод автоматически доскролит (вверх/вниз) до указанного в параметре элемента. Ограничение 10 скроллов.  // влево, вправо скролл будет реализован в след итерациях // 

2) Добавлены умные лонг вэйтеры(45 секунд) для желающих работать на прод/рс контурах

3) Переписана логика методов dsl_tap() , dsl_typeText() , dsl_doubleTap() - теперь если в параметрах указать опциональный needWait -> сработает проверка на хитбл с ожиданием и ретраем, если параметр не указать, то будет обычный tap() / typeText()  / doubleTap()

ВАЖНО! По умолчанию всегда needWait = False

4) Добавлен dsl_tap(withNumberOfTaps) - аналог нативного мульти тапа

5) Добавлен dsl_count - аналог нативного count

6) Добавлена приставка "dsl" к перемнной stringValue

7) Переписан dsl_forceTap() - теперь реализация работает через передачу координат

8) Добавлен паблик модификатор для переменных :  как dsl_exist / dsl_isSelected / dsl_isHittable / dsl_isEnabled