### PR TITLE
TUTUID-2974: Поправить CoreUITestKit

### DIFF
--- a/Sources/CoreUITestKit/AllureReportExtensions.swift
+++ b/Sources/CoreUITestKit/AllureReportExtensions.swift
@@ -5,55 +5,42 @@
 import XCTest
 
 // MARK: Методы для адаптации юай тестов к выгрузке в Allure ТестОпс
-extension XCTestCase {
-    /// Наименование модуля содержащего тесты. В случае чекаута - "Чекаут iOS Autotests"
-    public func feature(_ values: String...) {
-        label(name: "feature", values: values)
-    }
+/// Наименование модуля содержащего тесты. В случае чекаута - "Чекаут iOS Autotests"
+public func feature(_ values: String...) {
+    label(name: "feature", values: values)
+}
 
-    /// Наименование блока содержащего набор тестов. Например "Экран детализации"
-    public func story(_ stories: String...) {
-        label(name: "story", values: stories)
-        deviceInfo()
-    }
-    
-    public func tag(_ tag: String...) {
-        label(name: "tag", values: tag)
-    }
+/// Наименование блока содержащего набор тестов. Например "Экран детализации"
+public func story(_ stories: String...) {
+    label(name: "story", values: stories)
+    deviceInfo()
+}
 
-    /// В эту обертку заворачиваем логические блоки в тесте
-    public func step(_ name: String, step: () -> Void) {
-        XCTContext.runActivity(named: name) { _ in
-            step()
-        }
-    }
+public func tag(_ tag: String...) {
+    label(name: "tag", values: tag)
+}
 
-    /// Модель девайса на котором тестируем. Пока данные - хардкод
-    public func deviceInfo() {
-        description(
-            name: "Device info",
-            value: "Model name: Iphone11, Version OS: iOS 16.2"
-        )
-    }
-    
-    /// Используем для получания скриншота с места падения теста
-    public func takeScreenshot(name screenshotName: String? = nil) {
-        let screenshot = XCUIScreen.main.screenshot()
-        let attach = XCTAttachment(screenshot: screenshot, quality: .medium)
-        attach.name = screenshotName ?? name + "_" + UUID().uuidString
-        attach.lifetime = .keepAlways
-        add(attach)
+/// В эту обертку заворачиваем логические блоки в тесте
+public func step(_ name: String, step: () -> Void) {
+    XCTContext.runActivity(named: name) { _ in
+        step()
     }
 }
 
-extension XCTestCase {
-    private func description(name: String, value: String) {
-        XCTContext.runActivity(named: "allure.description:\(name): \(value)", block: { _ in })
-    }
+/// Модель девайса на котором тестируем. Пока данные - хардкод
+public func deviceInfo() {
+    description(
+        name: "Device info",
+        value: "Model name: Iphone11, Version OS: iOS 16.2"
+    )
+}
 
-    private func label(name: String, values: [String]) {
-        for value in values {
-            XCTContext.runActivity(named: "allure.label.\(name):\(value)", block: { _ in })
-        }
+private func label(name: String, values: [String]) {
+    values.forEach {
+        XCTContext.runActivity(named: "allure.label.\(name): \($0)") { _ in }
     }
+}
+
+private func description(name: String, value: String) {
+    XCTContext.runActivity(named: "allure.description:\(name): \(value)") { _ in }
 }

--- a/Sources/CoreUITestKit/XCTAssertFunctions.swift
+++ b/Sources/CoreUITestKit/XCTAssertFunctions.swift
@@ -1,0 +1,75 @@
+//
+// Copyright © 2023 LLC "Globus Media". All rights reserved.
+//
+
+import XCTest
+
+public func dsl_XCTAssertTrue(
+    XCUIElement: XCUIElement,
+    action: XCUIElement.Action,
+    errorMessage: @autoclosure () -> String,
+    file: StaticString = #file,
+    line: UInt = #line
+) {
+    XCTContext.runActivity(named: "Проверка элемента '\(XCUIElement)' на \(action.self)" ) { _ in
+        XCTAssertTrue(
+            XCUIElement.checkAction(action),
+            errorMessage(),
+            file: file,
+            line: line
+        )
+    }
+}
+
+public func dsl_XCTAssertFalse(
+    XCUIElement: XCUIElement,
+    action: XCUIElement.Action,
+    errorMessage: @autoclosure () -> String,
+    file: StaticString = #file,
+    line: UInt = #line
+) {
+    XCTContext.runActivity(named: "Проверка элемента '\(XCUIElement)' на не \(action.self)" ) { _ in
+        XCTAssertFalse(
+            XCUIElement.checkAction(action),
+            errorMessage(),
+            file: file,
+            line: line
+        )
+    }
+}
+
+public func dsl_XCTAssertEqual<T: Equatable>(
+    expression1: T,
+    expression2: T,
+    errorMessage: @autoclosure () -> String,
+    file: StaticString = #file,
+    line: UInt = #line
+) {
+    XCTContext.runActivity(named: "Проверить значение \(expression1) на равенство с \(expression2)") { _ in
+        XCTAssertEqual(
+            expression1,
+            expression2,
+            errorMessage(),
+            file: file,
+            line: line
+        )
+    }
+}
+
+public func dsl_XCTAssertNotEqual<T: Equatable>(
+    expression1: T,
+    expression2: T,
+    errorMessage: @autoclosure () -> String,
+    file: StaticString = #file,
+    line: UInt = #line
+) {
+    XCTContext.runActivity(named: "Проверить значение \(expression1) на неравенство с  \(expression2)") { _ in
+        XCTAssertNotEqual(
+            expression1,
+            expression2,
+            errorMessage(),
+            file: file,
+            line: line
+        )
+    }
+}

--- a/Sources/CoreUITestKit/XCTestCase+.swift
+++ b/Sources/CoreUITestKit/XCTestCase+.swift
@@ -2,53 +2,15 @@
 // Copyright © 2023 LLC "Globus Media". All rights reserved.
 //
 
-import Foundation
 import XCTest
 
 extension XCTestCase {
-    public func dsl_XCTAssertTrue(XCUIElement: XCUIElement, action: XCUIElement.Action, errorMessage: @autoclosure () -> String, file: StaticString = #file, line: UInt = #line) {
-        XCTContext.runActivity(named: "Проверка элемента '\(XCUIElement)' на \(action.self)" ) { _ in
-            XCTAssertTrue(
-                XCUIElement.checkAction(action),
-                errorMessage(),
-                file: file,
-                line: line
-            )
-        }
-    }
-
-    public func dsl_XCTAssertFalse(XCUIElement: XCUIElement, action: XCUIElement.Action, errorMessage: @autoclosure () -> String, file: StaticString = #file, line: UInt = #line) {
-        XCTContext.runActivity(named: "Проверка элемента '\(XCUIElement)' на не \(action.self)" ) { _ in
-            XCTAssertFalse(
-                XCUIElement.checkAction(action),
-                errorMessage(),
-                file: file,
-                line: line
-            )
-        }
-    }
-
-    public func dsl_XCTAssertEqual<T: Equatable>(expression1: T, expression2: T, errorMessage: @autoclosure () -> String, file: StaticString = #file, line: UInt = #line) {
-        XCTContext.runActivity(named: "Проверить значение \(expression1) на равенство с \(expression2)") { _ in
-            XCTAssertEqual(
-                expression1,
-                expression2,
-                errorMessage(),
-                file: file,
-                line: line
-            )
-        }
-    }
-    
-    public func dsl_XCTAssertNotEqual<T: Equatable>(expression1: T, expression2: T, errorMessage: @autoclosure () -> String, file: StaticString = #file, line: UInt = #line) {
-        XCTContext.runActivity(named: "Проверить значение \(expression1) на неравенство с  \(expression2)") { _ in
-            XCTAssertNotEqual(
-                expression1,
-                expression2,
-                errorMessage(),
-                file: file,
-                line: line
-            )
-        }
+    /// Используем для получания скриншота с места падения теста
+    public func takeScreenshot(name screenshotName: String? = nil) {
+        let screenshot = XCUIScreen.main.screenshot()
+        let attach = XCTAttachment(screenshot: screenshot, quality: .medium)
+        attach.name = screenshotName ?? name + "_" + UUID().uuidString
+        attach.lifetime = .keepAlways
+        add(attach)
     }
 }


### PR DESCRIPTION
[TUTUID-2974: Поправить CoreUITestKit](https://hq.tutu.ru/browse/TUTUID-2974)

проблема: 
Ранее `XCTestCase` обычно использовался только там, где описывались тестовые кейсы (в файлах самих тестов)
но так как функциональность CoreUITestKit была добавлена к `XCTestCase` пришлось подписывать под этот класс все файлы, например в userspace или tutuid это BaseScreen, под который подписаны все экраны для тестирования (на которых описывается просто кнопки, переиспользумые функции и так далее), но кажется это является избыточным действием.
Поэтому предлагаю вынести "dsl_..." функции и "методы для адаптации юай тестов" из `extension XCTestCase` и сделать их просто функциями фреймворка.



